### PR TITLE
Remove engines spec from package.json, add circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: 5.11.1

--- a/package.json
+++ b/package.json
@@ -12,10 +12,6 @@
     "react-component",
     "interpolation"
   ],
-  "engines": {
-    "node": ">=5.11.1",
-    "npm": ">=3.8.6"
-  },
   "scripts": {
     "compile": "babel -sd lib/ src/",
     "prepublish": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "interpolation"
   ],
   "engines": {
-    "node": ">=4.3.0",
+    "node": ">=5.11.1",
     "npm": ">=3.8.6"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "interpolation"
   ],
   "engines": {
-    "node": ">=4.2.3"
+    "node": ">=4.3.0",
+    "npm": ">=3.8.6"
   },
   "scripts": {
     "compile": "babel -sd lib/ src/",


### PR DESCRIPTION
Requiring npm 3 because of https://phabricator.babeljs.io/T2706 (see https://github.com/Automattic/interpolate-components/pull/2#issuecomment-225456347) -- I chose 3.8.6 because that's what Calypso currently requires.

node 4.2.3 has a [security issue](https://github.com/nodejs/node/blob/v4.2.3/CHANGELOG.md#2015-12-04-version-423-argon-lts-rvagg), hence upgrading to >= 4.3.0

/cc @aduth for review
