### PR TITLE
Update version to 1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 /npm-debug.log*
 .DS_Store
 lib/
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.0
+* Update to Babel 6 and bump node testing version to 5.11.1
+
 ## 1.0.5
 
 * Bump to allow for React ^15.1.0, still supporting ^0.14.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interpolate-components",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Convert strings into structured React components.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This updates interpolate components to version 1.1.0 and closes #6 After merging, we should add a tag and `npm publish`

cc @ockham @rralian @aduth 
