### PR TITLE
Update npmignore so we do not publish files by accident

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,4 @@
 src/
+/npm-debug.log*
+.DS_Store
+.idea/


### PR DESCRIPTION
Fixes #4 to add entries from .gitignore to .npmignore. This will prevent us from publishing extra files. From the docs: 

`All files in the package directory are included if no local .gitignore or .npmignore file exists. If both files exist and a file is ignored by .gitignore but not by .npmignore then it will be included.`
https://docs.npmjs.com/cli/publish

cc @aduth @rralian @ockham 
