### PR TITLE
move react to a dev dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.1
+* Move React and React-Dom to dev dependencies
+
 ## 1.1.0
 * Update to Babel 6 and bump node testing version to 5.11.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interpolate-components",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Convert strings into structured React components.",
   "repository": {
     "type": "git",
@@ -23,7 +23,9 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "babel-register": "^6.9.0",
-    "mocha": "^2.3.4"
+    "mocha": "^2.3.4",
+    "react": "^0.14.3 || ^15.1.0",
+    "react-dom": "^0.14.3 || ^15.1.0"
   },
   "bugs": {
     "url": "https://github.com/Automattic/interpolate-components/issues"
@@ -33,9 +35,7 @@
     "test": "test"
   },
   "dependencies": {
-    "react": "^0.14.3 || ^15.1.0",
-    "react-addons-create-fragment": "^0.14.3 || ^15.1.0",
-    "react-dom": "^0.14.3 || ^15.1.0"
+    "react-addons-create-fragment": "^0.14.3 || ^15.1.0"
   },
   "author": "Bob Ralian <bob.ralian@gmail.com> (http://github.com/rralian)",
   "license": "GPL-2.0"


### PR DESCRIPTION
`interpolate-components` only uses `React` directly from test files, so lets move the dependencies to devDependencies.