### PR TITLE
Remove react-addons-create-fragment dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.2-alpha.1
+* Remove `react-addons-create-fragment` dependency, use `cloneElement` to specify a key manually instead.
+
 ## 1.1.1
 * Drop deprecated React.createClass, React.DOM from test
 * Bump to allow for React ^16.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interpolate-components",
-  "version": "1.1.1",
+  "version": "1.1.2-alpha.1",
   "description": "Convert strings into structured React components.",
   "repository": {
     "type": "git",
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "react": "^0.14.3 || ^15.1.0 || ^16.0.0",
-    "react-addons-create-fragment": "^0.14.3 || ^15.1.0",
     "react-dom": "^0.14.3 || ^15.1.0 || ^16.0.0"
   },
   "author": "Bob Ralian <bob.ralian@gmail.com> (http://github.com/rralian)",


### PR DESCRIPTION
Use `cloneElement` to specify a key manually instead. Needs testing!

TODO before merging: Change package version to `1.1.2`.

To Test
-------
See https://github.com/Automattic/wp-calypso/pull/19658