### PR TITLE
Bump to allow for React 16, fix test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.1
+* Drop deprecated React.createClass, React.DOM from test
+* Bump to allow for React ^16.0.0
+
 ## 1.1.0
 * Update to Babel 6 and bump node testing version to 5.11.1
 

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "test": "test"
   },
   "dependencies": {
-    "react": "^0.14.3 || ^15.1.0",
+    "react": "^0.14.3 || ^15.1.0 || ^16.0.0",
     "react-addons-create-fragment": "^0.14.3 || ^15.1.0",
-    "react-dom": "^0.14.3 || ^15.1.0"
+    "react-dom": "^0.14.3 || ^15.1.0 || ^16.0.0"
   },
   "author": "Bob Ralian <bob.ralian@gmail.com> (http://github.com/rralian)",
   "license": "GPL-2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interpolate-components",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Convert strings into structured React components.",
   "repository": {
     "type": "git",

--- a/test/test.jsx
+++ b/test/test.jsx
@@ -11,16 +11,13 @@ import React from 'react';
 import interpolateComponents from '../src/index';
 
 describe( 'interpolate-components', () => {
-	const input = React.DOM.input();
-	const div = React.DOM.div();
+	const input = <input />;
+	const div = <div />;
 	const link = <a href="#" />;
 	const em = <em />;
-	const CustomComponentClass = React.createClass( {
-		displayName: 'CustomComponentClass',
-		render() {
-			return <span className="special">{ this.props.intro }{ this.props.children }</span>;
-		}
-	} );
+	const CustomComponentClass = ( { children, intro } ) => (
+		<span className="special">{ intro }{ children }</span>
+	);
 
 	describe( 'with default container', () => {
 		it( 'should return a react object with a span container', () => {


### PR DESCRIPTION
Broken out of #11.

To test:
* `rm -r node_modules/`
* `npm install`
* `grep version node_modules/react/package.json` (should return 16.something)
* `npm run test` should pass